### PR TITLE
Reactive signals fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,8 @@
 node_modules/
-jsdoc/
-signal/
 src/
 .vscode
 *.sh
 *.ps1
-esbuild.config.js
 out.js
 *.html
 vite.config.js

--- a/dev-types.d.ts
+++ b/dev-types.d.ts
@@ -51,7 +51,6 @@ declare global {
 
   interface MutableRefObject {
     current: Current & object;
-    refId: number;
     nextElementSibling: Element['nextElementSibling'] | null;
     prevElementSibling: Element['previousElementSibling'] | null;
     parent: Element['parentElement'] | null;

--- a/dom/helpers.ts
+++ b/dom/helpers.ts
@@ -70,7 +70,7 @@ export function fillInChildren(
   return (child: ChildrenType[number]) => {
     if (typeof child === "object") {
       // signal check
-      if ((child as Signal).$$__reactive) {
+      if ((child as Signal)?.$$__reactive) {
         const text = addText(element);
         // @ts-expect-error
         function textEff() {

--- a/dom/helpers.ts
+++ b/dom/helpers.ts
@@ -1,5 +1,7 @@
 import { Signal, Store } from "../primitives/classes";
-import { callEffect, removeEffect } from "../primitives/index";
+import { isReactive } from "../primitives/helpers";
+import { effect } from "../primitives/index";
+import { nonNull, raise } from "../shared";
 
 export function checkDataType(value: any) {
   return (
@@ -42,26 +44,8 @@ export function getSignalValue(signal: Signal) {
   } else return signal as any;
 }
 
-export function raise(message: string) {
-  throw `${message}`;
-}
-
-export function warn(message: string) {
-  console.warn(message);
-}
-
-export function isNull(value: any) {
-  return value === null || value === undefined;
-}
-
-export function entries(obj: object) {
-  return Object.entries(obj);
-}
-
-export function isReactiveValue(value: Signal | Store, prop: string) {
-  if (value.$$__reactive) {
-    raise(`The ${prop} prop value cannot be reactive.`);
-  }
+export function raiseIfReactive(value: Signal | Store, prop: string) {
+  isReactive(value) && raise(`The ${prop} prop value cannot be reactive.`);
 }
 
 export function fillInChildren(
@@ -71,19 +55,23 @@ export function fillInChildren(
     if (typeof child === "object") {
       // signal check
       if ((child as Signal)?.$$__reactive) {
+        const signal = child as Signal;
         const text = addText(element);
         // @ts-expect-error
         function textEff() {
-          text.textContent = getSignalValue(child as any) as any;
+          text.textContent = nonNull(signal.value, "");
         }
-        text.addEventListener("remove:node", function removeRxn(e) {
-          // remove the effect;
-          removeEffect(textEff, child as any);
-          e.currentTarget?.removeEventListener?.("remove:node", removeRxn);
-        });
-        callEffect(textEff, [child as any]);
+        text.addEventListener(
+          "remove:node",
+          () => signal.removeEffect(textEff),
+          {
+            once: true,
+          }
+        );
+        effect(textEff);
       } else element?.append?.(child as unknown as string);
-    } else if (checkDataType(child)) element?.append?.(createText(child as any));
+    } else if (checkDataType(child))
+      element?.append?.(createText(child as any));
   };
 }
 
@@ -104,11 +92,8 @@ export const directiveMap = {
         `The bind:ref directive's value cannot be reactive, it must be a MutableRefObject.`
       );
     value["current"] = element;
-    (async () => {
-      await Promise.resolve()
-      parseRef(value)
-    })()
-  }
+    queueMicrotask(() => parseRef(value));
+  },
 } as const;
 
 export function handleDirectives_(
@@ -116,7 +101,10 @@ export function handleDirectives_(
   directiveValue: {} & MutableRefObject,
   element: NixixElementType
 ) {
-  directiveMap?.[bindtype as keyof typeof directiveMap]?.(directiveValue, element);
+  directiveMap?.[bindtype as keyof typeof directiveMap]?.(
+    directiveValue,
+    element
+  );
 }
 
 export function parseRef(refObject: MutableRefObject) {

--- a/dom/index.ts
+++ b/dom/index.ts
@@ -1,17 +1,12 @@
+import { isNull, nonNull, raise, warn } from "../shared";
 import { Signal } from "../primitives/classes";
-import { isFunction } from "../primitives/helpers";
-import { callEffect, removeEffect } from "../primitives/index";
+import { entries, isFunction } from "../primitives/helpers";
+import { effect } from "../primitives/index";
 import Component from "./Component";
 import {
   addChildren,
-  checkDataType,
-  entries,
-  getSignalValue,
   handleDirectives_,
-  isNull,
-  isReactiveValue,
-  raise,
-  warn,
+  raiseIfReactive,
 } from "./helpers";
 import { PROP_ALIASES, SVG_ELEMENTTAGS, SVG_NAMESPACE } from "./utilVars";
 
@@ -31,7 +26,10 @@ type GlobalStore = {
   reactiveScope: boolean;
 };
 
-export const nixixStore = { commentForLF: false, reactiveScope: true } as GlobalStore;
+export const nixixStore = {
+  commentForLF: false,
+  reactiveScope: true,
+} as GlobalStore;
 
 function removeNode(node: Element | Text) {
   const isConnected = node?.isConnected;
@@ -39,11 +37,6 @@ function removeNode(node: Element | Text) {
   node?.dispatchEvent?.(new Event("remove:node"));
   node?.childNodes?.forEach?.((child) => removeNode(child as any));
   return isConnected;
-}
-
-async function doBGWork(fn: CallableFunction) {
-  await Promise.resolve();
-  fn();
 }
 
 function setAttribute(
@@ -56,30 +49,21 @@ function setAttribute(
     return warn(
       `The ${attrName} prop cannot be null or undefined. Skipping attribute parsing.`
     );
-  // signal check
   if ((attrValue as Signal).$$__reactive) {
+    const signal = attrValue as Signal;
     // @ts-expect-error
     function propEff() {
-      type === "propertyAttribute"
-        ? // @ts-ignore
-          (element[attrName] = getSignalValue(attrValue))
-        : element.setAttribute(
-            attrName,
-            getSignalValue(attrValue as any) as any
-          );
+      setProp(element, attrName, type!, signal.value)
     }
-    element.addEventListener("remove:node", function removeRxn(e) {
-      // remove the effect;
-      removeEffect(propEff, attrValue as any);
-      e.currentTarget?.removeEventListener?.("remove:node", removeRxn);
-    });
-    callEffect(propEff, [attrValue as any]);
-  } else if (checkDataType(attrValue)) {
-    type === "propertyAttribute"
-      ? // @ts-ignore
-        (element[attrName] = attrValue)
-      : element.setAttribute(attrName, attrValue as any);
-  }
+    element.addEventListener(
+      "remove:node",
+      () => signal.removeEffect(propEff),
+      {
+        once: true,
+      }
+    );
+    effect(propEff);
+  } else setProp(element, attrName, type!, attrValue)
 }
 
 function setStyle(element: NixixElementType, styleValue: StyleValueType) {
@@ -87,32 +71,30 @@ function setStyle(element: NixixElementType, styleValue: StyleValueType) {
     return warn(
       `The style prop cannot be null or undefined. Skipping attribute parsing.`
     );
+
   const cssStyleProperties = entries(styleValue) as [string, ValueType][];
   for (let [property, value] of cssStyleProperties) {
-    // typed as display to remove the ts error
     let styleKey = property as "display";
-    if (isNull(value)) {
+    value ??
       warn(
         `The ${styleKey} CSS property cannot be null or undefined. Skipping CSS property parsing.`
       );
-      continue;
-    }
 
-    // signal check
     if ((value as Signal).$$__reactive) {
+      const signal = value as Signal;
       // @ts-expect-error
       function styleEff() {
-        element["style"][styleKey] = getSignalValue(value as any) as any;
+        element["style"][styleKey] = nonNull(signal.value, '');
       }
-      element.addEventListener("remove:node", function removeRxn(e) {
-        // remove the effect;
-        removeEffect(styleEff, value as any);
-        e.currentTarget?.removeEventListener?.("remove:node", removeRxn);
-      });
-      callEffect(styleEff, [value as any]);
-    } else {
-      element["style"][styleKey] = value as string;
-    }
+      element.addEventListener(
+        "remove:node",
+        () => signal.removeEffect(styleEff),
+        {
+          once: true,
+        }
+      );
+      effect(styleEff);
+    } else element["style"][styleKey] = nonNull(value, '');
   }
 }
 
@@ -135,7 +117,7 @@ function setProps(props: Proptype | null, element: NixixElementType) {
           return warn(
             `The ${k} prop cannot be null or undefined. Skipping prop parsing`
           );
-        isReactiveValue(v as any, k);
+        raiseIfReactive(v as any, k);
         const domAttribute = k.slice(3);
         element.addEventListener(domAttribute, v as any);
       } else if (k.startsWith("aria:")) {
@@ -157,7 +139,7 @@ function setProps(props: Proptype | null, element: NixixElementType) {
           return raise(
             `The ${k} directive value cannot be null or undefined. Skipping directive parsing`
           );
-        isReactiveValue(v as any, k);
+        raiseIfReactive(v as any, k);
         Nixix.handleDirectives(
           k.slice(5),
           v as unknown as MutableRefObject,
@@ -170,10 +152,18 @@ function setProps(props: Proptype | null, element: NixixElementType) {
   }
 }
 
-function setChildren(children: ChildrenType | null, element: NixixElementType) {
-  if (children != undefined || children != null) {
-    addChildren(children, element);
+function setProp(element: NixixElementType, attrName: any, type: TypeOf, value: any) {
+  switch (type === 'propertyAttribute') {
+    case true:
+      // @ts-expect-error
+      return element[attrName] = nonNull(value, '')
+    case false:
+      return element.setAttribute(attrName, `${nonNull(value, '')}`);
   }
+}
+
+function setChildren(children: ChildrenType | null, element: NixixElementType) {
+  if (children) return addChildren(children, element);
 }
 
 function buildComponent(
@@ -181,7 +171,7 @@ function buildComponent(
   props: Proptype,
   children: ChildrenType
 ) {
-  let returnedElement: any = null;
+  let returnedElement: any = '';
   if (isFunction(tagNameFC)) {
     const artificialProps = props || {};
     Boolean(children?.length) && (artificialProps.children = children);
@@ -195,7 +185,7 @@ function buildComponent(
         raise(
           `Specify a ` +
             "`jsx` method in your " +
-            `<${(tagNameFC as any).name}> class Component`
+            `<${(tagNameFC as any).name}> Class Component`
         );
       }
     } else {
@@ -223,7 +213,7 @@ function render(
     );
   nixixStore.commentForLF = config.commentForLF;
   addChildren((bool ? fn() : fn) as any, root);
-  doBGWork(() => (nixixStore["root"] = root));
+  nixixStore["root"] = root;
 }
 
 const Nixix = {

--- a/dom/index.ts
+++ b/dom/index.ts
@@ -1,19 +1,19 @@
+import { Signal } from "../primitives/classes";
+import { isFunction } from "../primitives/helpers";
 import { callEffect, removeEffect } from "../primitives/index";
-import { Signal, Store } from "../primitives/classes";
+import Component from "./Component";
 import {
-  raise,
   addChildren,
-  handleDirectives_,
-  warn,
-  getSignalValue,
   checkDataType,
-  isNull,
   entries,
+  getSignalValue,
+  handleDirectives_,
+  isNull,
   isReactiveValue,
+  raise,
+  warn,
 } from "./helpers";
 import { PROP_ALIASES, SVG_ELEMENTTAGS, SVG_NAMESPACE } from "./utilVars";
-import { isFunction } from "../primitives/helpers";
-import Component from "./Component";
 
 type GlobalStore = {
   commentForLF: boolean;
@@ -25,12 +25,13 @@ type GlobalStore = {
     [path: string]: string | Node | (string | Node)[] | any;
   };
   root?: Element;
+  /**
+   * this prop is for stores to be patched efficiiently
+   */
+  reactiveScope: boolean;
 };
 
-window["$$__NixixStore"] = {
-  commentForLF: false,
-} as GlobalStore;
-export const nixixStore = window.$$__NixixStore as GlobalStore;
+export const nixixStore = { commentForLF: false, reactiveScope: true } as GlobalStore;
 
 function removeNode(node: Element | Text) {
   const isConnected = node?.isConnected;
@@ -185,11 +186,17 @@ function buildComponent(
     const artificialProps = props || {};
     Boolean(children?.length) && (artificialProps.children = children);
     if (Object.getPrototypeOf(tagNameFC) === Component) {
-      const componentObject = new (tagNameFC as any)(artificialProps) as Component;
-      if (Object.getPrototypeOf(componentObject).jsx) 
+      const componentObject = new (tagNameFC as any)(
+        artificialProps
+      ) as Component;
+      if (Object.getPrototypeOf(componentObject).jsx)
         returnedElement = (componentObject as any).jsx(artificialProps);
       else {
-        raise(`Specify a ` + "`jsx` method in your " + `<${(tagNameFC as any).name}> class Component`)
+        raise(
+          `Specify a ` +
+            "`jsx` method in your " +
+            `<${(tagNameFC as any).name}> class Component`
+        );
       }
     } else {
       try {
@@ -257,4 +264,4 @@ const Nixix = {
 const create = Nixix.create;
 
 export default Nixix;
-export { create, render, setAttribute, removeNode, Component };
+export { Component, buildComponent, create, removeNode, render, setAttribute };

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "jsxImportSource": "types",
     "module": "es2020",
+    "noUnusedLocals": true,
     "types": ["./types", "@remix-run/router"],
     "moduleResolution": "Bundler",
     "skipLibCheck": true

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,7 +8,7 @@
     "module": "es2020",
     "types": ["./types", "@remix-run/router"],
     "moduleResolution": "Bundler",
-    "skipLibCheck": false
+    "skipLibCheck": true
   },
   "include": ["./**/*"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nixix",
-  "version": "2.0.10",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nixix",
-      "version": "2.0.10",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nixix",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "NixixJS is a lightweight JavaScript Library used for building reactive User Interfaces.",
   "main": "./dom/index.ts",
   "module": "./dom/index.ts",

--- a/primitives/Signal.ts
+++ b/primitives/Signal.ts
@@ -1,26 +1,40 @@
+import { EFFECT_STACK } from "./shared";
 import { type Primitive } from "./types";
 
-export interface Signal {
-  value: Primitive,
-  readonly $$__reactive: true,
-  $$__effects?: CallableFunction[],
-  toJSON(): Primitive;
-  [index: symbol]:  () => Primitive;
-}
-
-
-
 export class Signal {
-  constructor(public value: Primitive, public readonly $$__reactive: true, public $$__effects?: CallableFunction[]) {
+  $$__reactive = true;
+  $$__deps = new Set<CallableFunction>()
+
+  constructor(private _value: Primitive) {
     const symbol = Symbol.toPrimitive
+    // @ts-expect-error
     this[symbol] = function toPrimitive() {
       return this.value;
     }
-
   }
 
-  toJSON() {
+  public toJSON() {
     return this.value;
   }
+
+  get value() {
+    const RUNNING = EFFECT_STACK[EFFECT_STACK.length - 1];
+    if (RUNNING) this.$$__deps?.add(RUNNING);
+    return this._value
+  }
+
+  set value(newVal: Primitive) {
+    this._value = newVal;
+    this.$$__deps?.forEach(fn => fn?.())
+  }
+
+  public removeEffect(fn: CallableFunction) {
+    if (this.$$__deps?.has(fn)) {
+      this.$$__deps?.delete(fn) 
+      return true;
+    } else return false;
+  }
 }
+
+
 

--- a/primitives/Signal.ts
+++ b/primitives/Signal.ts
@@ -1,24 +1,26 @@
 import { type Primitive } from "./types";
 
-const primitivesMap = {
-  'string': String,
-  'boolean': Boolean,
-  'number': Number
-} as const
+export interface Signal {
+  value: Primitive,
+  readonly $$__reactive: true,
+  $$__effects?: CallableFunction[],
+  toJSON(): Primitive;
+  [index: symbol]:  () => Primitive;
+}
 
-type KeyofPMap = keyof typeof primitivesMap
+
 
 export class Signal {
   constructor(public value: Primitive, public readonly $$__reactive: true, public $$__effects?: CallableFunction[]) {
-    const ClassConstructor = primitivesMap[typeof value as KeyofPMap] as (any);
-    if (ClassConstructor) {
-      class _Signal extends ClassConstructor {
-        constructor(public value: any, public readonly $$__reactive: true, public $$__effects?: CallableFunction[]) {
-          super(value)
-        }
-      } 
-      return new _Signal(value, $$__reactive, []) as Signal
-    } else return { value, $$__reactive, $$__effects: [] } as Signal
+    const symbol = Symbol.toPrimitive
+    this[symbol] = function toPrimitive() {
+      return this.value;
+    }
+
+  }
+
+  toJSON() {
+    return this.value;
   }
 }
 

--- a/primitives/Store.ts
+++ b/primitives/Store.ts
@@ -5,14 +5,14 @@ import { nixixStore } from '../dom/index'
 
 type StoreProps<T extends object | any[]> = {
   value?: T;
-  $$__effects?: CallableFunction[];
+  $$__deps?: Set<CallableFunction>;
 };
 
 type StoreProxyHandler<T extends object> = ProxyHandler<T> & {
   signalMap: Map<string | symbol, ReturnType<typeof signal>>;
 };
 
-const skippedPropNames = ["$$__reactive", "$$__effects"] as const;
+const skippedPropNames = ["$$__reactive", "$$__deps"] as const;
 
 const arrayPropNames: (keyof Array<any>)[] = [ 'length' ]
 
@@ -56,11 +56,12 @@ function createStoreProxy<T = EmptyObject>(obj: object | any[]): T {
 }
 
 export class Store {
-  constructor({ value, $$__effects }: StoreProps<object | any[]>) {
+  constructor({ value }: StoreProps<object | any[]>) {
+    const $$__deps = new Set<CallableFunction>()
     // @ts-expect-error
     return Array.isArray(value)
-      ? new Store_Array({ value, $$__effects })
-      : new Store_Object({ value, $$__effects });
+      ? new Store_Array({ value, $$__deps })
+      : new Store_Object({ value, $$__deps });
   }
 }
 
@@ -77,7 +78,7 @@ class Store_Object {
       }
     });
     const proxyvalue = createStoreProxy<Store>(value!);
-    proxyvalue.$$__effects = []
+    proxyvalue.$$__deps = new Set();
     proxyvalue.$$__reactive = true;
     return proxyvalue;
   }
@@ -95,20 +96,19 @@ class Store_Array {
         }
       });
       const proxyvalue = createStoreProxy<Store>(value!);
-      proxyvalue.$$__effects = [],
+      proxyvalue.$$__deps = new Set();
       proxyvalue.$$__reactive = true;
     return proxyvalue;
   }
 }
 
 export interface Store {
-  $$__effects: CallableFunction[];
+  $$__deps: Set<CallableFunction>;
   $$__reactive: true;
   [index: string | number]: any;
 }
 
 // const value = {}
-
-// value.name // Signal { value: null, $$__reactive: true, $$__effects: [], toJSON: [Function: toJSON] }
+// value.name // Signal { value: null, $$__reactive: true, $$__deps: [], toJSON: [Function: toJSON] }
 // setValue({ name: 'John' })
-// value.name // Signal { value: 'John', $$__reactive: true, $$__effects: [], toJSON: [Function: toJSON] }
+// value.name // Signal { value: 'John', $$__reactive: true, $$__deps: [], toJSON: [Function: toJSON] }

--- a/primitives/Store.ts
+++ b/primitives/Store.ts
@@ -1,6 +1,7 @@
 import { entries, forEach, isPrimitive } from "./helpers";
 import { signal } from "../primitives";
 import { EmptyObject } from "../types";
+import { nixixStore } from '../dom/index'
 
 type StoreProps<T extends object | any[]> = {
   value?: T;
@@ -12,6 +13,7 @@ type StoreProxyHandler<T extends object> = ProxyHandler<T> & {
 };
 
 const skippedPropNames = ["$$__reactive", "$$__effects"] as const;
+
 const arrayPropNames: (keyof Array<any>)[] = [ 'length' ]
 
 function isArrayPropName(target: object | any[], p: any) {
@@ -23,7 +25,7 @@ function createStoreProxy<T = EmptyObject>(obj: object | any[]): T {
   const proxy = new Proxy<EmptyObject>(obj, {
     signalMap: new Map(),
     get(target, p) {
-      if (!(p in target)) return null; 
+      if (!(p in target) && !nixixStore.reactiveScope) return null; 
       const val = target[p];
       let returnedValue: any = null;
       const skipProps = skippedPropNames.includes(
@@ -104,3 +106,9 @@ export interface Store {
   $$__reactive: true;
   [index: string | number]: any;
 }
+
+// const value = {}
+
+// value.name // Signal { value: null, $$__reactive: true, $$__effects: [], toJSON: [Function: toJSON] }
+// setValue({ name: 'John' })
+// value.name // Signal { value: 'John', $$__reactive: true, $$__effects: [], toJSON: [Function: toJSON] }

--- a/primitives/helpers.ts
+++ b/primitives/helpers.ts
@@ -1,4 +1,5 @@
-import { nixixStore } from "../dom";
+import { type EmptyObject, nixixStore } from "../dom";
+import { Signal, Store } from "./classes";
 import { type NonPrimitive } from "./types";
 
 function incrementId(prop: keyof typeof nixixStore) {
@@ -11,6 +12,18 @@ function incrementId(prop: keyof typeof nixixStore) {
   }
   return nixixStore[prop];
 }
+
+function splitProps<T extends EmptyObject<any>>(obj: T, ...props: (keyof T)[]) {
+  const splittedProps: Record<any, any> = {};
+  forEach(props, (p) => {
+    if (p in obj) {
+      splittedProps[p] = obj[p];
+      delete obj[p]  
+    }
+  })
+  return splittedProps;
+}
+
 
 function entries(obj: object) {
   return Object.entries(obj);
@@ -45,7 +58,7 @@ function checkType(value: string | number | boolean) {
 
 function isPrimitive(value: any) {
   return (
-    ["string", "boolean", "number"].includes(typeof value) || isNull(value)
+    ["string", "boolean", "number", "bigint"].includes(typeof value) || isNull(value)
   );
 }
 
@@ -62,8 +75,13 @@ function forEach<T>(
   arr?.forEach?.(cb, thisArg);
 }
 
+function isReactive(value: any) {
+  return (value as Signal | Store).$$__reactive as boolean;
+}
+
+
 export {
-  incrementId,
+  splitProps,
   checkType,
   isNull,
   isPrimitive,
@@ -72,4 +90,5 @@ export {
   isFunction,
   entries,
   forEach,
+  isReactive
 };

--- a/primitives/index.ts
+++ b/primitives/index.ts
@@ -1,10 +1,22 @@
-import { Signal, Store } from "./classes";
-import { type EmptyObject } from "../dom";
-import { cloneObject, isFunction, isPrimitive, forEach } from "./helpers";
-import { getSignalValue, raise } from "../dom/helpers";
-import { patchObj } from "./patchObj";
-import type { Primitive, NonPrimitive, SetSignalDispatcher, Signal as Signal2 } from "./types";
+import { getSignalValue } from "../dom/helpers";
 import { nixixStore } from "../dom/index";
+import { raise } from "../shared";
+import { Signal, Store } from "./classes";
+import {
+  cloneObject,
+  forEach,
+  isFunction,
+  isPrimitive,
+  splitProps,
+} from "./helpers";
+import { patchObj } from "./patchObj";
+import { EFFECT_STACK } from "./shared";
+import type {
+  NonPrimitive,
+  Primitive,
+  SetSignalDispatcher,
+  Signal as Signal2,
+} from "./types";
 
 function callRef<R extends Element | HTMLElement>(ref: R): MutableRefObject {
   return {
@@ -22,13 +34,13 @@ function callSignal<S>(
   }
 ): [Signal2<S>, SetSignalDispatcher<S>] {
   let value: string | number | boolean = isFunction(initialValue)
-  ? (initialValue as Function)()
-  : initialValue;
+    ? (initialValue as Function)()
+    : initialValue;
   // value - in the worst case of it being an instance of object, throw an error.
   !isPrimitive(value) &&
     raise(`You must pass a primitve to the signal function`);
-   const initValue = new Signal(value, true, []);
-   const setter: SetSignalDispatcher<S> = function (newState) {
+  const initValue = new Signal(value);
+  const setter: SetSignalDispatcher<S> = function (newState) {
     let oldState = initValue.value;
     let newStatePassed = isFunction(newState)
       ? (newState as Function)(oldState)
@@ -37,26 +49,14 @@ function callSignal<S>(
       case config?.equals:
       case String(oldState) !== String(newStatePassed):
         initValue.value = newStatePassed;
-        initValue.$$__effects?.forEach((eff) => eff());
     }
-  }
+  };
   return [initValue as any, setter];
 }
 
-function splitProps<T extends EmptyObject<any>>(obj: T, ...props: (keyof T)[]) {
-  const splittedProps: Record<any, any> = {};
-  forEach(props, (p) => {
-    if (p in obj) {
-      splittedProps[p] = obj[p];
-      delete obj[p]  
-    }
-  })
-  return splittedProps;
-}
-
-function closeReactiveProxyScope(fn: (() => void)) {
+function closeReactiveProxyScope(fn: () => void) {
   nixixStore.reactiveScope = false;
-  fn()
+  fn();
   nixixStore.reactiveScope = true;
 }
 
@@ -66,26 +66,27 @@ function callStore<S extends NonPrimitive>(
     equals: boolean;
   }
 ): any[] {
-
   let value = cloneObject(
     isFunction(initialValue) ? (initialValue as Function)() : initialValue
   );
   let objCopy = cloneObject(value);
-  const initValue = new Store({ value: value, $$__effects: [] });
+  const initValue = new Store({ value });
   const setter = (newValue: (prev?: any) => any) => {
-    let reactiveProps: Record<string, any> = splitProps(initValue, '$$__effects', '$$__reactive');
-    let newValuePassed = isFunction(newValue)
-      ? newValue(objCopy)
-      : newValue;
+    let reactiveProps: Record<string, any> = splitProps(
+      initValue,
+      "$$__deps",
+      "$$__reactive"
+    );
+    let newValuePassed = isFunction(newValue) ? newValue(objCopy) : newValue;
     switch (true) {
       case config?.equals:
       default:
         closeReactiveProxyScope(() => patchObj(initValue, newValuePassed));
         patchObj(objCopy, newValuePassed);
         Object.assign(initValue, reactiveProps);
-        initValue?.$$__effects?.forEach?.((eff) => eff());
+        initValue?.$$__deps?.forEach?.((eff) => eff());
     }
-  }
+  };
 
   return [initValue, setter];
 }
@@ -125,61 +126,64 @@ function concat<T extends Signal>(
   }, expressions);
 }
 
-function pushFurtherDeps(
+function subscribeDeps(
   callbackFn: CallableFunction,
   furtherDependents?: (Signal | Store)[]
 ) {
   if (furtherDependents)
     resolveImmediate(() => {
       forEach(furtherDependents, (dep) => {
-        dep?.$$__reactive && pushInEffects(callbackFn, dep as Signal);
+        dep?.$$__reactive && addDep(callbackFn, dep as Signal);
       });
     });
 }
 
-function pushInEffects(cb: CallableFunction, dep: Signal | Store) {
-  // check if the dep is a Store then check if it is a Signal
-  let { $$__effects: effectsArray } = dep;
-  if (effectsArray) !effectsArray.includes?.(cb) && effectsArray.push(cb);
+function addDep(cb: CallableFunction, dep: Signal | Store) {
+  dep.$$__deps?.add(cb)
 }
 
-async function resolveImmediate(fn: CallableFunction) {
-  await Promise.resolve();
-  (async (cb: CallableFunction) => {
-    cb();
-  })(fn);
+function resolveImmediate(fn: CallableFunction) {
+  queueMicrotask(fn as () => void);
 }
 
 const effect = callEffect;
 
-function callEffect(
-  callbackFn: CallableFunction,
-  furtherDependents?: (Signal | Store)[]
-) {
-  pushFurtherDeps(callbackFn, furtherDependents);
-  resolveImmediate(callbackFn);
+function callEffect(callbackFn: CallableFunction) {
+  resolveImmediate(() => {
+    try {
+      EFFECT_STACK.push(callbackFn);
+      callbackFn();
+    } finally {
+      EFFECT_STACK.pop();
+    }
+  });
 }
 
-function callReaction(
-  callbackFn: CallableFunction,
-  furtherDependents?: (Signal | Store)[]
-) {
-  pushFurtherDeps(callbackFn, furtherDependents);
+const reaction = callReaction;
+
+function callReaction(callbackFn: CallableFunction, deps?: (Signal | Store)[]) {
+  subscribeDeps(callbackFn, deps);
 }
 
 function renderEffect(
   callbackFn: CallableFunction,
-  furtherDependents?: (Signal | Store)[],
+  furtherDependents?: (Signal | Store)[]
 ) {
-  window.addEventListener("DOMContentLoaded", function rendered() {
-    callbackFn();
-    this.window.removeEventListener("DOMContentLoaded", rendered);
-  });
-  pushFurtherDeps(callbackFn, furtherDependents);
+  window.addEventListener(
+    "DOMContentLoaded",
+    function rendered() {
+      callbackFn();
+    },
+    {
+      once: true,
+    }
+  );
+  subscribeDeps(callbackFn, furtherDependents);
 }
 
 function dispatchSignalRemoval(signal: Store | Signal) {
-  delete signal.$$__effects;
+  // @ts-expect-error
+  delete signal.$$__deps;
   // @ts-expect-error
   delete signal.$$__reactive;
 }
@@ -194,39 +198,27 @@ function removeSignal<T extends Store | Signal = Store | Signal>(
     : dispatchSignalRemoval(signals);
 }
 
-function dispatchEffectRemoval(fn: CallableFunction, signal: Store | Signal) {
-  const { $$__effects: effects } = signal;
-  if (effects) {
-    if (effects.includes(fn)) effects.splice(effects.indexOf(fn), 1);
-    return true;
-  } else return false;
-}
-
-function removeEffect(fn: CallableFunction, signal: Store | Signal) {
-  dispatchEffectRemoval(fn, signal);
-}
-
 // This is only for simplicity
 const signal = callSignal;
 const store = callStore;
 
 export {
+  Signal,
+  Store,
+  callEffect,
+  callReaction,
   callRef,
   callSignal,
-  signal,
-  store,
-  memo,
-  concat,
   callStore,
-  getValueType,
   getSignalValue,
-  splitProps,
-  effect,
-  callEffect,
-  renderEffect,
-  callReaction,
-  Store,
-  Signal,
+  getValueType,
   removeSignal,
-  removeEffect,
+  renderEffect,
+  splitProps,
+  memo,
+  signal,
+  concat,
+  store,
+  effect,
+  reaction
 };

--- a/primitives/shared.ts
+++ b/primitives/shared.ts
@@ -1,0 +1,1 @@
+export const EFFECT_STACK: CallableFunction[] = []

--- a/primitives/types/index.d.ts
+++ b/primitives/types/index.d.ts
@@ -7,10 +7,10 @@ export type SetStoreDispatcher<S> = (newValue: S | ((prev: S) => S)) => void;
 
 export type Signal<S> = S extends null | undefined
   ? {
-    value: S;
+    readonly value: S;
   } & string
   : {
-    value: S;
+    readonly value: S;
   } & S;
 
 export type Store<O> = {
@@ -80,6 +80,7 @@ type Deps = (Signal<Primitive> | Store<NonPrimitive>)[];
  *
  * @param fn callback function to return the initialValue
  * @param deps array of signals or stores to which when changed re-runs and updates the memo's value;
+ * 
  */
 export function memo<S extends Primitive>(
   fn: () => S,
@@ -93,53 +94,53 @@ export function memo<S extends NonPrimitive>(
 /**
  * Creates a memoized concatenated string from a template string literal containing a signal(s);
  * 
- * `USAGE`
+ * @example
  * ```jsx
  * import { concat, signal } from 'nixix/primitives';
  * const [display, setDisplay] = signal<'flex' | 'hidden'>('flex');
  * const View = () => <div className={concat`${display} flex-col`} >I am a DIV</div>
- * 
  * ```
  */
 export function concat(...templ: Array<Primitive | Signal<Primitive> | TemplateStringsArray>): MemoSignal<string>;
 
 /**
- * @deprecated PLEASE DO NOT USE THIS FUNCTION, USE `callEffect` or `callReaction`
- * Tracks the closest (signal or store) and calls the callback function whenever the (signal or store)'s value changes.
- * If there is no signal or store, it does no tracking.
- *
- * @param callbackFn callback function to be called once all the synchronous code has finished running.
+ * Places the callback function to be passed to it in aa stack, so signal values acessed within the callback can subscribe the callback to themselves.
+ * 
+ * @example 
+ * ```jsx
+ * import { effect, signal } from 'nixix/primitves';
+ * 
+ * const [count, setCount] = signal(0);
+ * effect(() => {
+ *  console.log(count.value)
+ * })
+ * ```
  */
 export function effect(
   callbackFn: CallableFunction,
-  deps?: Deps
 ): void;
 
-/**
- *
- * @param callbackFn callback function to be executed
- * @param deps furtherDependencies array to subscribe to
- * This function doesn't work like the effect function that subscribes it's callback function to the last signal or store created.
- */
-export function callEffect(callbackFn: CallableFunction, deps?: Deps): void;
+export const callEffect: typeof effect
 
 /**
- *
- * @param callbackFn callback function to be executed
- * @param deps furtherDependencies array to subscribe to
- * This function doesn't work like the effect function that subscribes it's callback function to the last signal or store created. It does not call the callback else just subscribes to all of the signals or stores in the dependencies array
+ * Takes a callback function and a dependency array. Containing signals or stores to subscribe to. The callback will be called only when te signal changes;
+ * 
+ * @example 
+ * ```jsx
+ * import { callReaction, signal } from 'nixix/primitives';
+ * 
+ * const [count, setCount] = signal(0);
+ * callReaction(() => {
+ *  console.log(count.value)
+ * }, [count])
+ * ```
  */
-export function callReaction(callbackFn: CallableFunction, deps?: Deps): void;
+export function callReaction(callbackFn: CallableFunction, deps: Deps): void;
 
-/**
- * Tracks the closest (signal or store) and calls the callback function whenever the (signal or store)'s value changes.
- * If there is no signal or store, it does no tracking.
- *
- * @param callbackFn callback function to be called once the DOM content has loaded.
- */
+export const reaction: typeof callReaction
+
 export function renderEffect(
   callbackFn: CallableFunction,
-  deps?: Deps
 ): void;
 
 export function removeSignal(
@@ -149,6 +150,7 @@ export function removeSignal(
 export function removeEffect(fn: CallableFunction, signal: Deps[number]): void;
 
 /**
+ * @example
  * ```jsx
  * This function is used to get a reference to a dom element. To get the element you want to manipulate, add the 'bind:ref' prop with it's value as the ref variable. 
  * import { callRef } from 'nixix';

--- a/router/Form.ts
+++ b/router/Form.ts
@@ -1,24 +1,37 @@
-import { removeUnusedProps } from "../view-components/helpers";
-import Nixix from "../dom";
-import type { FormActionProps } from "./types/index";
-import { getLink } from "./helpers";
+import { create } from "../dom";
 import { callAction } from "./callAction";
+import { getLink, lastElement, len } from "./helpers";
+import type { FormActionProps } from "./types/index";
+import { matchRoutes } from "@remix-run/router";
+import { agnosticRouteObjects } from "./utils";
+import { raise } from "dom/helpers";
 
-const { create } = Nixix;
+export const Form = ({
+  children,
+  "on:submit": onSubmit,
+  ...rest
+}: FormActionProps) => {
+  let path = `${rest.action}` as `/${string}`;
+  const routeMatches = matchRoutes(agnosticRouteObjects, {
+    pathname: path
+  });
 
-export const Form = (props: FormActionProps) => {
-  const { children, "on:submit": onSubmit } =
-    removeUnusedProps<FormActionProps>(props, "children", "on:submit");
-  const subMitHandler: FormActionProps["on:submit"] = (e) => {
-    e.preventDefault();
-    onSubmit?.(e)
-    const path = getLink(props?.action) as `/`;
-    const formData = new FormData(e.currentTarget);
-    callAction({ path, formData });
-  };
-  return create(
-    "form",
-    { ...props, "on:submit": subMitHandler },
-    children as any
-  );
+  if (routeMatches && len(routeMatches) !== 0) {
+    const routeMatch = lastElement(routeMatches) as any;
+    const { action, path: rPath } = routeMatch
+    if (!action) 
+      raise(`Specify a route action function for ${rPath}`)
+    const subMitHandler: FormActionProps["on:submit"] = (e) => {
+      e.preventDefault();
+      onSubmit?.(e);
+      const formData = new FormData(e.currentTarget);
+      path = `${rest.action}`
+      callAction({ path, formData });
+    };
+    return create(
+      "form",
+      { ...rest, "on:submit": subMitHandler },
+      children as any
+    );
+  } else raise(`There are no route matches for ${path}`);
 };

--- a/router/Router.ts
+++ b/router/Router.ts
@@ -18,6 +18,7 @@ export const Router = {
   push: (path: string) => {
     let { $$__routeStore } = nixixStore as Required<typeof nixixStore>;
     path = getLink(path);
+    if ($$__routeStore.currentRoute?.path === path) return;
     const routeMatches = matchRoutes(agnosticRouteObjects, {
       pathname: path,
     })!;

--- a/router/callAction.ts
+++ b/router/callAction.ts
@@ -1,15 +1,34 @@
 import { matchRoutes } from "@remix-run/router";
 import { raise } from "../dom/helpers";
-import { callEffect, callReaction, callStore } from "../primitives";
+import { callStore } from "../primitives";
 import type { EmptyObject } from "../types";
 import { navigate } from "./Router";
 import { lastElement, len } from "./helpers";
-import type {
+import {
   actionData as ActionDataFunction,
   ActionProps,
   PathToRoute,
 } from "./types/index";
 import { agnosticRouteObjects } from "./utils";
+
+export class ActionDataHandler {
+  private static actionRoute: Set<PathToRoute> = new Set();
+
+  private static pathMap: Map<PathToRoute, ((data: any) => void)> = new Map();
+
+  static subscribeAction(path: PathToRoute, fn: (data: any) => void) {
+    this.pathMap.set(path, fn);
+  }
+
+  static addActionRoute(path: PathToRoute) {
+    this.actionRoute.add(path);
+  }
+
+  static setData(path: PathToRoute, data: any[] | object) {
+    const { actionRoute } = this;
+    actionRoute.has(path)
+  }
+}
 
 type CallActionConfig = {
   path: `/${string}`;
@@ -22,41 +41,39 @@ export async function callAction({ path, formData }: CallActionConfig) {
   });
 
   if (routeMatches && len(routeMatches) !== 0) {
-    const routeMatch = lastElement(routeMatches);
+    const routeMatch = lastElement(routeMatches) as any;
     const payLoad = {
       params: routeMatch.params || {},
       request: new Request(path),
     } as ActionProps;
     payLoad.request.formData = async () => formData;
     // @ts-ignore
-    const { action, actionSignal } = routeMatch.route;
-    (action?.(payLoad as any) as Promise<EmptyObject>).then((val) => {
-      actionSignal[1](val);
-    });
-  }
+    const { action, path: rPath } = routeMatch.route;
+    const data = (await action?.(payLoad)) as Promise<EmptyObject>;
+    // rPath -> /movies/:id
+    ActionDataHandler.setData(rPath, data);
+    return;
+  } else raise(`Specify a route action function for ${path}`);
 }
 
 export const actionData: typeof ActionDataFunction = (
   path: PathToRoute,
   value: any
 ) => {
-  const [val, setVal] = callStore(value)!;
-  callEffect(() => {
-    const routeMatches = matchRoutes(agnosticRouteObjects, {
-      pathname: path,
-    });
-
-    if (routeMatches && len(routeMatches) !== 0) {
-      const routeMatch = lastElement(routeMatches);
-      // @ts-ignore
-      const [adStore] =
-        (routeMatch.route.actionSignal as typeof valStore) || [];
-      if (!adStore) raise(`Specify an action function for ${path}`);
-      callReaction(() => {
-        setVal(adStore);
-        navigate(path);
-      }, [adStore]);
-    } else raise(`There are no route matches for ${path}.`);
+  const routeMatches = matchRoutes(agnosticRouteObjects, {
+    pathname: path,
   });
-  return val as any;
+
+  if (routeMatches && len(routeMatches) !== 0) {
+    const routeMatch = lastElement(routeMatches) as any;
+    const { action, path: rPath } = routeMatch
+    if (!action)
+      raise(`Specify an action function for ${rPath}`);
+    const [val, setVal] = callStore(value)!;
+    ActionDataHandler.subscribeAction(path, (data) => {
+      setVal(data);
+      navigate(path);
+    });
+    return val as any;
+  } else raise(`There are no route matches for ${path}.`);
 };

--- a/router/callLoader.ts
+++ b/router/callLoader.ts
@@ -2,9 +2,14 @@ import {
   AgnosticRouteMatch,
   AgnosticRouteObject,
   LoaderFunction,
+  matchRoutes
 } from "@remix-run/router";
-import { getWinPath } from "./helpers";
+import { getWinPath, lastElement, len } from "./helpers";
 import type { LoaderProps } from "./types/index";
+import { store, type NonPrimitive, callEffect, callReaction } from "../primitives";
+import { agnosticRouteObjects } from "./utils";
+import { raise } from "../dom/helpers";
+import { navigate } from "./Router";
 
 export async function callLoader({
   route,
@@ -17,6 +22,27 @@ export async function callLoader({
   // do something with the data here;
   const val =
     (await (route?.loader as LoaderFunction)?.(loaderArgs)) ||
-    (async () => {})();
+    (async () => undefined)();
   return val;
+}
+
+export function loaderData(path: `/${string}`, value: NonPrimitive) {
+  const [val, setVal] = store(value);
+  callEffect(() => {
+    const routeMatches = matchRoutes(agnosticRouteObjects, {
+      pathname: path,
+    });
+
+    if (routeMatches && len(routeMatches) !== 0) {
+      const routeMatch = lastElement(routeMatches);
+      // @ts-ignore
+      const [adStore] =
+        (routeMatch.route.actionSignal) || [];
+      if (!adStore) raise(`Specify an action function for ${path}`);
+      callReaction(() => {
+        setVal(adStore);
+        navigate(path);
+      }, [adStore]);
+    } else raise(`There are no route matches for ${path}.`);
+  });
 }

--- a/router/handleLoc.ts
+++ b/router/handleLoc.ts
@@ -4,23 +4,24 @@ import type { EmptyObject } from "../types";
 import { callLoader } from "./callLoader";
 import { navigate } from "./Router";
 import { isFunction } from "../primitives/helpers";
+import { buildComponent } from "../dom/index";
 
 export function handleLocation() {
   const {
     $$__routeStore: { provider, routeMatch },
   } = nixixStore as Required<typeof nixixStore>;
-  callLoader(routeMatch!).then((val) => {
+  callLoader(routeMatch!).then((data) => {
     const { redirect } = nixixStore.$$__routeStore!;
     // if redirect, stop executing and navigate again;
     if (typeof redirect === "string") {
       nixixStore.$$__routeStore!.redirect = null;
       return navigate(redirect as `/${string}`);
     }
-    switchRoutes({ provider, routeMatch });
+    switchRoutes({ provider, routeMatch, loaderData: data });
   });
 }
 
-export function switchRoutes({ provider, routeMatch }: EmptyObject) {
+export function switchRoutes({ provider, routeMatch, loaderData }: EmptyObject) {
   const route = routeMatch!.route;
   const element = route.element;
   switch (element) {
@@ -28,11 +29,11 @@ export function switchRoutes({ provider, routeMatch }: EmptyObject) {
     case undefined:
       break;
     default:
-      if (nixixStore.$$__routeStore?.currentRoute === route) return;
       nixixStore.$$__routeStore!.currentRoute! = route;
       let routePage: any;
+      
       if (isFunction(element)) {
-        routePage = element()
+        routePage = buildComponent(element, {}, []);
         route.element = routePage
       } else routePage = element;
       provider?.replace(createFragment(routePage));

--- a/router/types/index.d.ts
+++ b/router/types/index.d.ts
@@ -1,5 +1,6 @@
 import {
   AnchorHTMLAttributes,
+  Component,
   EmptyObject,
   ExoticComponent,
   FormHTMLAttributes,
@@ -31,7 +32,10 @@ export interface RouteLink<T extends string>
   to: T;
 }
 export interface RouteConfig<T extends string> {
-  element: NixixNode | (() => NixixNode);
+  /**
+   * element should be called only when we hit a route match
+   */
+  element: (() => NixixNode) | typeof Component;
   children?: NixixNode;
   path?: T;
   errorRoute?: boolean;

--- a/shared.ts
+++ b/shared.ts
@@ -1,0 +1,19 @@
+export function raise(message: string) {
+  throw `${message}`;
+}
+
+export function warn(message: string) {
+  console.warn(message);
+}
+
+export function isNull(value: any) {
+  return value === null || value === undefined;
+}
+
+export function entries(obj: object) {
+  return Object.entries(obj);
+}
+
+export function nonNull<V>(value: V, fallback: any) {
+  return isNull(value) ? fallback : value;
+}

--- a/vite-plugin/index.js
+++ b/vite-plugin/index.js
@@ -14,14 +14,13 @@ export default function NixixHMR(projectRoot, dev) {
       if (regExp) {
         const prelude = `if (import.meta.hot) {
           import.meta.hot?.accept((newMod) => {
-            delete nixixStore['$$__routeStore']
-            agnosticRouteObjects.length = 0;
-            // @ts-ignore
-            (nixixStore?.root)?.replaceChildren?.("");
+            delete $nixixStore['$$__routeStore']
+            $agnosticRouteObjects.length = 0;
+            ($nixixStore?.root)?.replaceChildren?.("");
             newMod?.default?.();
           });
         };
-        import { agnosticRouteObjects } from "${dev ? 'router/utils' : 'nixix/router/utils'}";
+        import { agnosticRouteObjects as $agnosticRouteObjects } from "${dev ? 'router/utils' : 'nixix/router/utils'}";
         `;
         return {
           code: `${prelude}${code}`,
@@ -34,20 +33,20 @@ export default function NixixHMR(projectRoot, dev) {
 }
 
 const esbuildOptions = {
-  jsxFactory: "Nixix.create",
+  jsxFactory: "$Nixix.create",
   jsxFragment: '"fragment"',
   jsxImportSource: "nixix",
   jsxDev: false,
   jsx: "transform",
-  jsxInject: "import Nixix, { nixixStore } from 'nixix/dom';",
+  jsxInject: "import $Nixix, { nixixStore as $nixixStore } from 'nixix/dom';",
   minifyIdentifiers: true,
 };
 
 const devEsbuildOptions = {
-  jsxFactory: "Nixix.create",
+  jsxFactory: "$Nixix.create",
   jsxFragment: "'fragment'",
   jsxImportSource: "./index.js",
-  jsxInject: 'import Nixix, { nixixStore } from "dom"',
+  jsxInject: 'import $Nixix, { nixixStore as $nixixStore } from "dom"',
 };
 
 export { devEsbuildOptions, esbuildOptions };


### PR DESCRIPTION
Fixed reactive signals. 

Here are notable improvements: 

- When any signal's .value property is accessed in a callback passed to an effect  or callEffect function, it adds that function as a dependency of itself. 
- The callReaction function accepts a second argument - a dependecies array, to which it will subscribe its first argument to each of the signals in the array.

