### PR TITLE
Bind directives update

### DIFF
--- a/dom/helpers.ts
+++ b/dom/helpers.ts
@@ -1,7 +1,8 @@
 import { Signal, Store } from "../primitives/classes";
 import { isReactive } from "../primitives/helpers";
 import { effect } from "../primitives/index";
-import { nonNull, raise } from "../shared";
+import { isFunction, nonNull, raise } from "../shared";
+import { type RefFunction } from "./types";
 
 export function checkDataType(value: any) {
   return (
@@ -86,13 +87,22 @@ export function addChildren(
 }
 
 export const directiveMap = {
-  ref: (value: MutableRefObject, element: NixixElementType) => {
-    if ((value as unknown as Signal).$$__reactive)
+  ref: (
+    value: MutableRefObject | RefFunction<any>,
+    element: NixixElementType
+  ) => {
+    if (isReactive(value))
       raise(
         `The bind:ref directive's value cannot be reactive, it must be a MutableRefObject.`
       );
-    value["current"] = element;
-    queueMicrotask(() => parseRef(value));
+    if (isFunction(value))
+      return (value as RefFunction<any>)({ current: element });
+    else {
+      const ref = value as MutableRefObject;
+      ref["current"] = element;
+      queueMicrotask(() => parseRef(ref));
+      return 
+    }
   },
 } as const;
 

--- a/dom/helpers.ts
+++ b/dom/helpers.ts
@@ -101,34 +101,33 @@ const bindDirectiveMap = {
       const ref = value as MutableRefObject;
       ref["current"] = element;
       queueMicrotask(() => parseRef(ref));
-      return 
+      return;
     }
   },
-  value: (
-    value: Signal,
-    element: HTMLInputElement
-  ) => {
+  value: (value: Signal, element: HTMLInputElement | HTMLSelectElement) => {
     if (!isReactive(value))
-      raise(
-        `The bind:value directive's value must be a signal.`
-      );
+      raise(`The bind:value directive's value must be a signal.`);
+    effect(() => {
       element.value = value.value as any;
-      (element as HTMLInputElement | HTMLDetailsElement).addEventListener('input', ({currentTarget}) => {
-        value.value = (currentTarget as any)?.value;
-      })
-    }
-  }
+    });
+    element.addEventListener("input", ({ currentTarget }) => {
+      value.value = (currentTarget as any)?.value;
+    });
+  },
+};
 
 export const directiveMap = {
-  'bind:': bindDirectiveMap,
-  'animate:': {
-    in: (value: object, element: NixixElementType) => undefined
-  }
+  "bind:": bindDirectiveMap,
+  "animate:": {
+    in: (value: object, element: NixixElementType) => undefined,
+  },
 } as const;
 
 type DirectiveMap = typeof directiveMap;
 
-type KeyOfAllDirectives = keyof DirectiveMap['animate:'] | keyof DirectiveMap['bind:']
+type KeyOfAllDirectives =
+  | keyof DirectiveMap["animate:"]
+  | keyof DirectiveMap["bind:"];
 
 export function handleDirectives_(
   prefix: keyof DirectiveMap,

--- a/dom/index.ts
+++ b/dom/index.ts
@@ -1,14 +1,9 @@
-import { isNull, nonNull, raise, warn } from "../shared";
 import { Signal } from "../primitives/classes";
 import { entries } from "../primitives/helpers";
-import { isFunction } from "../shared";
 import { effect } from "../primitives/index";
+import { isFunction, isNull, nonNull, raise, warn } from "../shared";
 import Component from "./Component";
-import {
-  addChildren,
-  handleDirectives_,
-  raiseIfReactive,
-} from "./helpers";
+import { addChildren, handleDirectives_, raiseIfReactive } from "./helpers";
 import { PROP_ALIASES, SVG_ELEMENTTAGS, SVG_NAMESPACE } from "./utilVars";
 
 type GlobalStore = {
@@ -54,7 +49,7 @@ function setAttribute(
     const signal = attrValue as Signal;
     // @ts-expect-error
     function propEff() {
-      setProp(element, attrName, type!, signal.value)
+      setProp(element, attrName, type!, signal.value);
     }
     element.addEventListener(
       "remove:node",
@@ -64,7 +59,7 @@ function setAttribute(
       }
     );
     effect(propEff);
-  } else setProp(element, attrName, type!, attrValue)
+  } else setProp(element, attrName, type!, attrValue);
 }
 
 function setStyle(element: NixixElementType, styleValue: StyleValueType) {
@@ -85,7 +80,7 @@ function setStyle(element: NixixElementType, styleValue: StyleValueType) {
       const signal = value as Signal;
       // @ts-expect-error
       function styleEff() {
-        element["style"][styleKey] = nonNull(signal.value, '');
+        element["style"][styleKey] = nonNull(signal.value, "");
       }
       element.addEventListener(
         "remove:node",
@@ -95,7 +90,7 @@ function setStyle(element: NixixElementType, styleValue: StyleValueType) {
         }
       );
       effect(styleEff);
-    } else element["style"][styleKey] = nonNull(value, '');
+    } else element["style"][styleKey] = nonNull(value, "");
   }
 }
 
@@ -121,31 +116,12 @@ function setProps(props: Proptype | null, element: NixixElementType) {
         raiseIfReactive(v as any, k);
         const domAttribute = k.slice(3);
         element.addEventListener(domAttribute, v as any);
-      } else if (k.startsWith("aria:")) {
-        Nixix.handleDynamicAttrs({
-          element,
-          attrPrefix: "aria:",
-          attrName: k,
-          attrValue: v as ValueType,
-        });
-      } else if (k.startsWith("stroke:")) {
-        Nixix.handleDynamicAttrs({
-          element,
-          attrPrefix: "stroke:",
-          attrName: k,
-          attrValue: v as ValueType,
-        });
       } else if (k.startsWith("bind:")) {
         if (isNull(v))
-          return raise(
+          return warn(
             `The ${k} directive value cannot be null or undefined. Skipping directive parsing`
           );
-        raiseIfReactive(v as any, k);
-        Nixix.handleDirectives(
-          k.slice(5),
-          v as unknown as MutableRefObject,
-          element
-        );
+        Nixix.handleDirectives('bind:', k.slice(5), v, element);
       } else {
         setAttribute(element, k, v as ValueType);
       }
@@ -153,13 +129,18 @@ function setProps(props: Proptype | null, element: NixixElementType) {
   }
 }
 
-function setProp(element: NixixElementType, attrName: any, type: TypeOf, value: any) {
-  switch (type === 'propertyAttribute') {
+function setProp(
+  element: NixixElementType,
+  attrName: any,
+  type: TypeOf,
+  value: any
+) {
+  switch (type === "propertyAttribute") {
     case true:
       // @ts-expect-error
-      return element[attrName] = nonNull(value, '')
+      return (element[attrName] = nonNull(value, ""));
     case false:
-      return element.setAttribute(attrName, `${nonNull(value, '')}`);
+      return element.setAttribute(attrName, `${nonNull(value, "")}`);
   }
 }
 
@@ -172,7 +153,7 @@ function buildComponent(
   props: Proptype,
   children: ChildrenType
 ) {
-  let returnedElement: any = '';
+  let returnedElement: any = "";
   if (isFunction(tagNameFC)) {
     const artificialProps = props || {};
     Boolean(children?.length) && (artificialProps.children = children);
@@ -205,7 +186,7 @@ function render(
   root: HTMLElement,
   config: {
     commentForLF: boolean;
-  } = { commentForLF: true }
+  } = { commentForLF: false }
 ) {
   let bool = isFunction(fn);
   if (!bool)

--- a/dom/index.ts
+++ b/dom/index.ts
@@ -1,6 +1,7 @@
 import { isNull, nonNull, raise, warn } from "../shared";
 import { Signal } from "../primitives/classes";
-import { entries, isFunction } from "../primitives/helpers";
+import { entries } from "../primitives/helpers";
+import { isFunction } from "../shared";
 import { effect } from "../primitives/index";
 import Component from "./Component";
 import {

--- a/primitives/helpers.ts
+++ b/primitives/helpers.ts
@@ -1,36 +1,20 @@
-import { type EmptyObject, nixixStore } from "../dom";
+import { type EmptyObject } from "../dom";
 import { Signal, Store } from "./classes";
 import { type NonPrimitive } from "./types";
-
-function incrementId(prop: keyof typeof nixixStore) {
-  if (nixixStore[prop] === undefined) {
-    // @ts-ignore
-    nixixStore[prop] = 0;
-  } else {
-    // @ts-ignore
-    nixixStore[prop] = nixixStore[prop] + 1;
-  }
-  return nixixStore[prop];
-}
 
 function splitProps<T extends EmptyObject<any>>(obj: T, ...props: (keyof T)[]) {
   const splittedProps: Record<any, any> = {};
   forEach(props, (p) => {
     if (p in obj) {
       splittedProps[p] = obj[p];
-      delete obj[p]  
+      delete obj[p];
     }
-  })
+  });
   return splittedProps;
 }
 
-
 function entries(obj: object) {
   return Object.entries(obj);
-}
-
-function isFunction(val: any) {
-  return typeof val === "function";
 }
 
 function cloneObject<T extends NonPrimitive>(object: T) {
@@ -58,7 +42,8 @@ function checkType(value: string | number | boolean) {
 
 function isPrimitive(value: any) {
   return (
-    ["string", "boolean", "number", "bigint"].includes(typeof value) || isNull(value)
+    ["string", "boolean", "number", "bigint"].includes(typeof value) ||
+    isNull(value)
   );
 }
 
@@ -79,16 +64,14 @@ function isReactive(value: any) {
   return (value as Signal | Store).$$__reactive as boolean;
 }
 
-
 export {
-  splitProps,
   checkType,
-  isNull,
-  isPrimitive,
-  removeChars,
   cloneObject,
-  isFunction,
   entries,
   forEach,
-  isReactive
+  isNull,
+  isPrimitive,
+  isReactive,
+  removeChars,
+  splitProps,
 };

--- a/primitives/index.ts
+++ b/primitives/index.ts
@@ -5,7 +5,6 @@ import { Signal, Store } from "./classes";
 import {
   cloneObject,
   forEach,
-  isFunction,
   isPrimitive,
   splitProps,
 } from "./helpers";
@@ -17,6 +16,7 @@ import type {
   SetSignalDispatcher,
   Signal as Signal2,
 } from "./types";
+import { isFunction } from "../shared";
 
 function callRef<R extends Element | HTMLElement>(ref: R): MutableRefObject {
   return {

--- a/router/handleLoc.ts
+++ b/router/handleLoc.ts
@@ -3,7 +3,7 @@ import { nixixStore } from "../dom";
 import type { EmptyObject } from "../types";
 import { callLoader } from "./callLoader";
 import { navigate } from "./Router";
-import { isFunction } from "../primitives/helpers";
+import { isFunction } from "../shared";
 import { buildComponent } from "../dom/index";
 
 export function handleLocation() {

--- a/shared.ts
+++ b/shared.ts
@@ -17,3 +17,7 @@ export function entries(obj: object) {
 export function nonNull<V>(value: V, fallback: any) {
   return isNull(value) ? fallback : value;
 }
+
+export function isFunction(val: any) {
+  return typeof val === "function";
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@
 import * as CSS from "csstype";
 import { AriaRole } from "./aria";
 import * as NativeEvents from "./eventhandlers";
-import { MutableRefObject } from "../primitives/types";
+import { MutableRefObject, Signal } from "../primitives/types";
 
 type Booleanish = boolean | "true" | "false";
 
@@ -51,9 +51,7 @@ declare namespace Nixix {
 
   interface CSSProperties extends CSS.Properties<string, number> {}
 
-  interface DOMAttributes<T> {
-    children?: NixixNode;
-    innerHTML?: string;
+  interface EventAttributes<T> {
 
     // clipboard events
     "on:copy"?: NativeEvents.ClipboardEventHandler<T>;
@@ -258,45 +256,50 @@ declare namespace Nixix {
     key?: number;
   }
 
+  interface DOMAttributes<T> extends EventAttributes<T> {
+    children?: NixixNode;
+    innerHTML?: string;
+  }
+
   interface AriaAttributes {
     /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
-    "aria:activedescendant"?: string;
+    "aria-activedescendant"?: string;
     /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
-    "aria:atomic"?: Booleanish;
+    "aria-atomic"?: Booleanish;
     /**
      * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
      * presented if they are made.
      */
-    "aria:autocomplete"?: "none" | "inline" | "list" | "both";
+    "aria-autocomplete"?: "none" | "inline" | "list" | "both";
     /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
-    "aria:busy"?: Booleanish;
+    "aria-busy"?: Booleanish;
     /**
      * Indicates the current "checked" Signal of checkboxes, radio buttons, and other widgets.
      * @see aria-pressed @see aria-selected.
      */
-    "aria:checked"?: boolean | "false" | "mixed" | "true";
+    "aria-checked"?: boolean | "false" | "mixed" | "true";
     /**
      * Defines the total number of columns in a table, grid, or treegrid.
      * @see aria-colindex.
      */
-    "aria:colcount"?: number;
+    "aria-colcount"?: number;
     /**
      * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
      * @see aria-colcount @see aria-colspan.
      */
-    "aria:colindex"?: number;
+    "aria-colindex"?: number;
     /**
      * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
      * @see aria-colindex @see aria-rowspan.
      */
-    "aria:colspan"?: number;
+    "aria-colspan"?: number;
     /**
      * Identifies the element (or elements) whose contents or presence are controlled by the current element.
      * @see aria-owns.
      */
-    "aria:controls"?: string;
+    "aria-controls"?: string;
     /** Indicates the element that represents the current item within a container or set of related elements. */
-    "aria:current"?:
+    "aria-current"?:
       | Booleanish
       | "page"
       | "step"
@@ -307,41 +310,41 @@ declare namespace Nixix {
      * Identifies the element (or elements) that describes the object.
      * @see aria-labelledby
      */
-    "aria:describedby"?: string;
+    "aria-describedby"?: string;
     /**
      * Identifies the element that provides a detailed, extended description for the object.
      * @see aria-describedby.
      */
-    "aria:details"?: string;
+    "aria-details"?: string;
     /**
      * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
      * @see aria-hidden @see aria-readonly.
      */
-    "aria:disabled"?: Booleanish;
+    "aria-disabled"?: Booleanish;
     /**
      * Indicates what functions can be performed when a dragged object is released on the drop target.
      * @deprecated in ARIA 1.1
      */
-    "aria:dropeffect"?: "none" | "copy" | "execute" | "link" | "move" | "popup";
+    "aria-dropeffect"?: "none" | "copy" | "execute" | "link" | "move" | "popup";
     /**
      * Identifies the element that provides an error message for the object.
      * @see aria-invalid @see aria-describedby.
      */
-    "aria:errormessage"?: string;
+    "aria-errormessage"?: string;
     /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
-    "aria:expanded"?: Booleanish;
+    "aria-expanded"?: Booleanish;
     /**
      * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
      * allows assistive technology to override the general default of reading in document source order.
      */
-    "aria:flowto"?: string;
+    "aria-flowto"?: string;
     /**
      * Indicates an element's "grabbed" Signal in a drag-and-drop operation.
      * @deprecated in ARIA 1.1
      */
-    "aria:grabbed"?: Booleanish;
+    "aria-grabbed"?: Booleanish;
     /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
-    "aria:haspopup"?:
+    "aria-haspopup"?:
       | Booleanish
       | "menu"
       | "listbox"
@@ -352,67 +355,67 @@ declare namespace Nixix {
      * Indicates whether the element is exposed to an accessibility API.
      * @see aria-disabled.
      */
-    "aria:hidden"?: Booleanish;
+    "aria-hidden"?: Booleanish;
     /**
      * Indicates the entered value does not conform to the format expected by the application.
      * @see aria-errormessage.
      */
-    "aria:invalid"?: Booleanish | "grammar" | "spelling";
+    "aria-invalid"?: Booleanish | "grammar" | "spelling";
     /** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
-    "aria:keyshortcuts"?: string;
+    "aria-keyshortcuts"?: string;
     /**
      * Defines a string value that labels the current element.
      * @see aria-labelledby.
      */
-    "aria:label"?: string;
+    "aria-label"?: string;
     /**
      * Identifies the element (or elements) that labels the current element.
      * @see aria-describedby.
      */
-    "aria:labelledby"?: string;
+    "aria-labelledby"?: string;
     /** Defines the hierarchical level of an element within a structure. */
-    "aria:level"?: number;
+    "aria-level"?: number;
     /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
-    "aria:live"?: "off" | "assertive" | "polite";
+    "aria-live"?: "off" | "assertive" | "polite";
     /** Indicates whether an element is modal when displayed. */
-    "aria:modal"?: Booleanish;
+    "aria-modal"?: Booleanish;
     /** Indicates whether a text box accepts multiple lines of input or only a single line. */
-    "aria:multiline"?: Booleanish;
+    "aria-multiline"?: Booleanish;
     /** Indicates that the user may select more than one item from the current selectable descendants. */
-    "aria:multiselectable"?: Booleanish;
+    "aria-multiselectable"?: Booleanish;
     /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
-    "aria:orientation"?: "horizontal" | "vertical";
+    "aria-orientation"?: "horizontal" | "vertical";
     /**
      * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
      * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
      * @see aria-controls.
      */
-    "aria:owns"?: string;
+    "aria-owns"?: string;
     /**
      * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
      * A hint could be a sample value or a brief description of the expected format.
      */
-    "aria:placeholder"?: string;
+    "aria-placeholder"?: string;
     /**
      * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
      * @see aria-setsize.
      */
-    "aria:posinset"?: number;
+    "aria-posinset"?: number;
     /**
      * Indicates the current "pressed" Signal of toggle buttons.
      * @see aria-checked @see aria-selected.
      */
-    "aria:pressed"?: Booleanish | "mixed";
+    "aria-pressed"?: Booleanish | "mixed";
     /**
      * Indicates that the element is not editable, but is otherwise operable.
      * @see aria-disabled.
      */
-    "aria:readonly"?: Booleanish;
+    "aria-readonly"?: Booleanish;
     /**
      * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
      * @see aria-atomic.
      */
-    "aria:relevant"?:
+    "aria-relevant"?:
       | "additions"
       | "additions removals"
       | "additions text"
@@ -424,47 +427,47 @@ declare namespace Nixix {
       | "text additions"
       | "text removals";
     /** Indicates that user input is required on the element before a form may be submitted. */
-    "aria:required"?: Booleanish;
+    "aria-required"?: Booleanish;
     /** Defines a human-readable, author-localized description for the role of an element. */
-    "aria:roledescription"?: string;
+    "aria-roledescription"?: string;
     /**
      * Defines the total number of rows in a table, grid, or treegrid.
      * @see aria-rowindex.
      */
-    "aria:rowcount"?: number;
+    "aria-rowcount"?: number;
     /**
      * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
      * @see aria-rowcount @see aria-rowspan.
      */
-    "aria:rowindex"?: number;
+    "aria-rowindex"?: number;
     /**
      * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
      * @see aria-rowindex @see aria-colspan.
      */
-    "aria:rowspan"?: number;
+    "aria-rowspan"?: number;
     /**
      * Indicates the current "selected" Signal of various widgets.
      * @see aria-checked @see aria-pressed.
      */
-    "aria:selected"?: Booleanish;
+    "aria-selected"?: Booleanish;
     /**
      * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
      * @see aria-posinset.
      */
-    "aria:setsize"?: number;
+    "aria-setsize"?: number;
     /** Indicates if items in a table or grid are sorted in ascending or descending order. */
-    "aria:sort"?: "none" | "ascending" | "descending" | "other";
+    "aria-sort"?: "none" | "ascending" | "descending" | "other";
     /** Defines the maximum allowed value for a range widget. */
-    "aria:valuemax"?: number;
+    "aria-valuemax"?: number;
     /** Defines the minimum allowed value for a range widget. */
-    "aria:valuemin"?: number;
+    "aria-valuemin"?: number;
     /**
      * Defines the current value for a range widget.
      * @see aria-valuetext.
      */
-    "aria:valuenow"?: number;
+    "aria-valuenow"?: number;
     /** Defines the human readable text alternative of aria-valuenow for a range widget. */
-    "aria:valuetext"?: string;
+    "aria-valuetext"?: string;
   }
 
   interface HTMLAttributes<T>
@@ -752,6 +755,7 @@ declare namespace Nixix {
     accept?: string;
     alt?: string;
     autocomplete?: "off" | "on";
+    "bind:value"?: Signal<string | number | null>;
     capture?: boolean | "user" | "environment"; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
     checked?: boolean;
     crossorigin?: string;
@@ -1254,25 +1258,25 @@ declare namespace Nixix {
     "strikethrough-thickness"?: number | string | null;
     string?: number | string | null;
     stroke?: string | null;
-    "stroke:dasharray"?: number | string | null;
-    "stroke:dashoffset"?: number | string | null;
-    "stroke:linecap"?:
+    "stroke-dasharray"?: number | string | null;
+    "stroke-dashoffset"?: number | string | null;
+    "stroke-linecap"?:
       | "butt"
       | "round"
       | "square"
       | "inherit"
       | undefined
       | null;
-    "stroke:linejoin"?:
+    "stroke-linejoin"?:
       | "miter"
       | "round"
       | "bevel"
       | "inherit"
       | undefined
       | null;
-    "stroke:miterlimit"?: string | null;
-    "stroke:opacity"?: number | string | null;
-    "stroke:width"?: number | string | null;
+    "stroke-miterlimit"?: string | null;
+    "stroke-opacity"?: number | string | null;
+    "stroke-width"?: number | string | null;
     surfaceScale?: number | string | null;
     systemLanguage?: number | string | null;
     tableValues?: number | string | null;
@@ -1313,18 +1317,18 @@ declare namespace Nixix {
     x?: number | string | null;
     xChannelSelector?: string | null;
     "x-height"?: number | string | null;
-    "xlink:actuate"?: string | null;
-    "xlink:arcrole"?: string | null;
-    "xlink:href"?: string | null;
-    "xlink:role"?: string | null;
-    "xlink:show"?: string | null;
-    "xlink:title"?: string | null;
-    "xlink:type"?: string | null;
-    "xml:base"?: string | null;
-    "xml:lang"?: string | null;
+    "xlink-actuate"?: string | null;
+    "xlink-arcrole"?: string | null;
+    "xlink-href"?: string | null;
+    "xlink-role"?: string | null;
+    "xlink-show"?: string | null;
+    "xlink-title"?: string | null;
+    "xlink-type"?: string | null;
+    "xml-base"?: string | null;
+    "xml-lang"?: string | null;
     xmlns?: string | null;
-    "xmlns:xlink"?: string | null;
-    "xml:space"?: string | null;
+    "xmlns-xlink"?: string | null;
+    "xml-space"?: string | null;
     y1?: number | string | null;
     y2?: number | string | null;
     y?: number | string | null;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -931,6 +931,7 @@ declare namespace Nixix {
 
   interface SelectHTMLAttributes<T> extends HTMLAttributes<T> {
     autocomplete?: string;
+    "bind:value"?: Signal<string>;
     disabled?: boolean;
     form?: string;
     multiple?: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -47,6 +47,8 @@ declare namespace Nixix {
 
   type RouteExoticComponent<T> = T;
 
+  type RefFunction<T> = (({current}: {current: T}) => void)
+
   interface CSSProperties extends CSS.Properties<string, number> {}
 
   interface DOMAttributes<T> {
@@ -248,8 +250,11 @@ declare namespace Nixix {
     "on:transitionendcapture"?: NativeEvents.TransitionEventHandler<T>;
   }
 
-  interface NixixAttributes<T> {
-    "bind:ref"?: MutableRefObject<T | null>;
+  interface BindDirectives<T> {
+    "bind:ref"?: MutableRefObject<T | null> | RefFunction<T>;
+  }
+
+  interface NixixAttributes<T> extends BindDirectives<T> {
     key?: number;
   }
 


### PR DESCRIPTION
Bind directives like bind:value now support two-way data flow. 

Here are a few improvements:

- <input> elements support the `bind:value` directive.

- All elements support functions as values for the `bind:ref` directive